### PR TITLE
Added `args` and `exclude_types` to hook type

### DIFF
--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -130,6 +130,15 @@ in
       default = [ ];
     };
 
+    exclude_types = mkOption {
+      type = types.listOf types.str;
+      description = lib.mdDoc
+        ''
+          List of file types to exclude. See [Filtering files with types](https://pre-commit.com/#plugins).
+        '';
+      default = [ ];
+    };
+
     pass_filenames = mkOption {
       type = types.bool;
       description = lib.mdDoc ''
@@ -177,6 +186,14 @@ in
       description = lib.mdDoc ''
         if true this hook will run even if there are no matching files.
       '';
+    };
+
+    args = mkOption {
+      type = types.listOf types.str;
+      description = lib.mdDoc ''
+        List of additional parameters to pass to the hook.
+      '';
+      default = [ ];
     };
   };
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2738,7 +2738,8 @@ in
           description = "Format shell files.";
           types = [ "shell" ];
           package = tools.shfmt;
-          entry = "${hooks.shfmt.package}/bin/shfmt -w -s -l";
+          entry = "${hooks.shfmt.package}/bin/shfmt -w -l";
+          args = [ "-s" ];
         };
       staticcheck =
         {


### PR DESCRIPTION
[Creating new hooks](https://pre-commit.com/#creating-new-hooks) allows for `args` and `exclude_types`.

In particular, I wanted to configure `shfmt` to not force the `-s` flag. I changed the default configuration for `shfmt` to have `args = [ "-s" ]` to not break anything for anybody, but it allows me to disable it, and add other flags.